### PR TITLE
Fix consumer initialization to properly encode config -> Properties when invoking make-consumer with just a config map

### DIFF
--- a/src/franzy/clients/consumer/client.clj
+++ b/src/franzy/clients/consumer/client.clj
@@ -337,7 +337,7 @@
   ([config :- cs/ConsumerConfig
     options :- (s/maybe cs/ConsumerOptions)]
     (-> config
-        ^Properties (config-codec/decode)
+        ^Properties (config-codec/encode)
         (KafkaConsumer.)
         (FranzConsumer. (defaults/make-default-consumer-options options))))
   ([config :- cs/ConsumerConfig

--- a/test/franzy/clients/consumer/client_tests.clj
+++ b/test/franzy/clients/consumer/client_tests.clj
@@ -1,0 +1,10 @@
+(ns franzy.clients.consumer.client-tests
+  (:require [midje.sweet :refer :all]
+            [franzy.clients.consumer.client :as cl]))
+
+(facts "Clients should instantiate properly."
+       (fact "Invoking make-consumer with just a config map should not throw a ClassCastException when converting config map to Properties instance."
+             (let [config {:bootstrap.servers "127.0.0.1"
+                           :value.deserializer "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+                           :value.serializer "org.apache.kafka.common.serialization.ByteArrayDeserializer"}]
+               (cl/make-consumer config) =not=> (throws ClassCastException "clojure.lang.PersistentArrayMap cannot be cast to java.util.Properties"))))


### PR DESCRIPTION
First of all: just want to thank you for creating what seems like an awesome set of Clojure libraries for Kafka. I'm really excited to see where this goes.

The reason for this pull request: I was fiddling around at the REPL and couldn't seem to instantiate a consumer when just passing a config map. Tracked the cause down to a minor typo, which is now fixed. Also added a very basic test case to cover the issue.

Thanks again for creating this library – really looking forward to diving in!
