### PR TITLE
Add support for 'schema.registry.url' property in ConsumerConfig and ProducerConfig schemas

### DIFF
--- a/src/franzy/clients/consumer/schema.clj
+++ b/src/franzy/clients/consumer/schema.clj
@@ -73,7 +73,8 @@
    (s/optional-key :ssl.cipher.suites)                        fs/StringOrStringList
    (s/optional-key :ssl.endpoint.identification.algorithm)    s/Str
    (s/optional-key :ssl.keymanager.algorithm)                 s/Str
-   (s/optional-key :ssl.trustmanager.algorithm)               s/Str})
+   (s/optional-key :ssl.trustmanager.algorithm)               s/Str
+   (s/optional-key :schema.registry.url)                      s/Str})
 
 (def ConsumerRecord
   "Schema for a Kafka Consumer Record.

--- a/src/franzy/clients/producer/schema.clj
+++ b/src/franzy/clients/producer/schema.clj
@@ -69,7 +69,8 @@
    (s/optional-key :ssl.cipher.suites)                        fs/StringOrStringList
    (s/optional-key :ssl.endpoint.identification.algorithm)    s/Str
    (s/optional-key :ssl.keymanager.algorithm)                 s/Str
-   (s/optional-key :ssl.trustmanager.algorithm)               s/Str})
+   (s/optional-key :ssl.trustmanager.algorithm)               s/Str
+   (s/optional-key :schema.registry.url)                      s/Str})
 
 (def ProducerRecord
   "Schema for a Kafka Producer Record.


### PR DESCRIPTION
Thank you so much for creating and maintaining this library – it's really a pleasure to use.

This PR adds an optional consumer and producer config key, `schema.registry.url`, so Franzy's Schema validations can play nice with the Confluent Platform.

Per Confluent's [documentation,](http://docs.confluent.io/1.0/schema-registry/docs/serializer-formatter.html#serializer-and-formatter) the `schema.registry.url` property should be in the general Properties passed to the Kafka Consumer on instantiation.

Currently, things work out of the box. It'd just be nice to have Schema validations work, too, instead of throwing an error.

Would also love to hear thoughts on potentially more idiomatic ways to accomplish this.
